### PR TITLE
Remove JAMStack from footer links

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -18,10 +18,6 @@ module.exports = {
         name: 'ReactJS Singapore',
         link: 'https://www.meetup.com/React-Singapore/',
       },
-      {
-        name: 'JAMStack Singapore',
-        link: 'https://www.meetup.com/JAMstack-Singapore/',
-      },
     ],
   },
   plugins: [


### PR DESCRIPTION
JAMStack appears on presentation mode shoutouts section, yet we do not have much to speak about. Suggest to remove and add it back when we have robust comments of them.