### PR TITLE
Removed Nut's talk from meetup 3 to avoid confusion.

### DIFF
--- a/content/meetups/3.md
+++ b/content/meetups/3.md
@@ -7,7 +7,6 @@ talks:
   - 15
   - 18
   - 19
-  - 22
   - 23
 title: '<RK⚡️ issue={3} />'
 meetupLink: https://www.meetup.com/React-Knowledgeable/events/264767450/


### PR DESCRIPTION
We can put it in to the 4th meetup. When it's ready (the talk and the meetup info).