### PR TITLE
let footer handle footerlinks query

### DIFF
--- a/src/components/Footer/index.jsx
+++ b/src/components/Footer/index.jsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { graphql, StaticQuery } from 'gatsby';
 import s from './s.module.scss';
 
 const Friend = ({ name, link }) => (
@@ -22,17 +23,39 @@ const Friend = ({ name, link }) => (
   </a>
 );
 
-export default ({ footerLinks }) => {
-  return (
-    <footer className={s.footer}>
-      <p>Built with love.</p>
-      <div className={s.friends}>
-        <span className={s.friendLabel}>Friends of RK:</span>
-        {!!footerLinks &&
-          footerLinks.map(link => (
-            <Friend key={`friend-link-${link.name}`} {...link} />
-          ))}
-      </div>
-    </footer>
-  );
-};
+const Footer = () => (
+  <StaticQuery
+    query={graphql`
+      query FooterQuery {
+        site {
+          siteMetadata {
+            footerLinks {
+              link
+              name
+            }
+          }
+        }
+      }
+    `}
+    render={({
+      site: {
+        siteMetadata: { footerLinks },
+      },
+    }) => {
+      return (
+        <footer className={s.footer}>
+          <p>Built with love.</p>
+          <div className={s.friends}>
+            <span className={s.friendLabel}>Friends of RK:</span>
+            {!!footerLinks &&
+              footerLinks.map(link => (
+                <Friend key={`friend-link-${link.name}`} {...link} />
+              ))}
+          </div>
+        </footer>
+      );
+    }}
+  />
+);
+
+export default Footer;

--- a/src/components/Layout/index.jsx
+++ b/src/components/Layout/index.jsx
@@ -14,7 +14,6 @@ export default props => {
     url,
     titleTemplate,
     twitter,
-    footerLinks,
     coverImage,
     className,
     onKeyPress,
@@ -60,7 +59,7 @@ export default props => {
         </p>
       </header>
       {children}
-      <Footer footerLinks={footerLinks} />
+      <Footer />
     </div>
   );
 };

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -10,15 +10,7 @@ import s from './styles.module.scss';
 export default ({
   data: {
     site: {
-      siteMetadata: {
-        title,
-        description,
-        url,
-        image,
-        twitter,
-        titleTemplate,
-        footerLinks,
-      },
+      siteMetadata: { title, description, url, image, twitter, titleTemplate },
     },
     meetups: { nodes: meetups },
     stories: { nodes: stories },
@@ -43,7 +35,6 @@ export default ({
         url,
         twitter,
         titleTemplate,
-        footerLinks,
       }}
     >
       <aside>
@@ -143,10 +134,6 @@ export const pageQuery = graphql`
         url
         twitter
         titleTemplate
-        footerLinks {
-          name
-          link
-        }
       }
     }
     meetups: allMarkdownRemark(

--- a/src/templates/Meetup/index.jsx
+++ b/src/templates/Meetup/index.jsx
@@ -98,7 +98,6 @@ export default ({
         url,
         twitter,
         titleTemplate,
-        footerLinks,
       }}
       className={s[mode]}
     >

--- a/src/templates/Story/index.jsx
+++ b/src/templates/Story/index.jsx
@@ -13,7 +13,6 @@ export default ({
         image,
         twitter,
         titleTemplate,
-        footerLinks,
       },
     },
     markdownRemark: {
@@ -32,7 +31,6 @@ export default ({
       url,
       twitter,
       titleTemplate,
-      footerLinks,
     }}
   >
     <main>
@@ -56,10 +54,6 @@ export const pageQuery = graphql`
         url
         twitter
         titleTemplate
-        footerLinks {
-          name
-          link
-        }
       }
     }
     markdownRemark(fields: { slug: { eq: $slug } }) {


### PR DESCRIPTION
what does this PR do
---
here's our footer component:
![image](https://user-images.githubusercontent.com/2055384/67615626-54085a00-f801-11e9-8caf-b46db4f058d3.png)

previously each page is querying footer links from site data and passing down to `<Footer />` component. this PR moves the query to `<Footer />` so that we don't have to keep remember passing it down for new pages.

note that the meetup pages are still querying the footer links from site meta data because it renders this extra section
![image](https://user-images.githubusercontent.com/2055384/67615619-40f58a00-f801-11e9-81eb-7f1a63581173.png)


cc @huijing 
