### PR TITLE
make talk go to internal talk page, add "external anchor" icon next to it that goes to the github issue page

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -104,17 +104,34 @@ export default ({
                     issues
                       // sorts by created descending, later talk comes up
                       .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
-                      .map(({ title, body, url, closed, createdAt }) => (
-                        <React.Fragment>
-                          <h4>
-                            <a href={url}>{title}</a>
-                            {!closed && (
-                              <span className={s.upcoming}>upcoming</span>
-                            )}
-                          </h4>
-                          <p className={s.topicIntro}>{parseBodyText(body)}</p>
-                        </React.Fragment>
-                      ))}
+                      .map(
+                        ({ title, body, url, closed, createdAt, number }) => (
+                          <React.Fragment>
+                            <h4 className={s.talkTitle}>
+                              <Link to={`/talks/${number}`}>{title}</Link>
+                              {!closed ? (
+                                <span className={s.upcoming}>upcoming</span>
+                              ) : null}
+                              <a
+                                className={s.externalLink}
+                                href={url}
+                                target="_blank"
+                              >
+                                <svg
+                                  className={s.externalLink__Icon}
+                                  xmlns="http://www.w3.org/2000/svg"
+                                  viewBox="0 -8 36 36"
+                                >
+                                  <path d="M 12.3125 0 C 10.425781 0.00390625 10.566406 0.507813 11.5625 1.5 L 14.78125 4.71875 L 9.25 10.25 C 8.105469 11.394531 8.105469 13.230469 9.25 14.375 L 11.6875 16.78125 C 12.832031 17.921875 14.667969 17.925781 15.8125 16.78125 L 21.34375 11.28125 L 24.5 14.4375 C 25.601563 15.539063 26 15.574219 26 13.6875 L 26 3.40625 C 26 -0.03125 26.035156 0 22.59375 0 Z M 4.875 5 C 2.183594 5 0 7.183594 0 9.875 L 0 21.125 C 0 23.816406 2.183594 26 4.875 26 L 16.125 26 C 18.816406 26 21 23.816406 21 21.125 L 21 14.75 L 18 17.75 L 18 21.125 C 18 22.160156 17.160156 23 16.125 23 L 4.875 23 C 3.839844 23 3 22.160156 3 21.125 L 3 9.875 C 3 8.839844 3.839844 8 4.875 8 L 8.3125 8 L 11.3125 5 Z"></path>
+                                </svg>
+                              </a>
+                            </h4>
+                            <p className={s.topicIntro}>
+                              {parseBodyText(body)}
+                            </p>
+                          </React.Fragment>
+                        )
+                      )}
                 </Card>
               ))}
         </div>
@@ -182,6 +199,7 @@ export const pageQuery = graphql`
                 title
                 body
                 url
+                number
                 closed
                 createdAt
               }

--- a/src/pages/s.module.scss
+++ b/src/pages/s.module.scss
@@ -61,3 +61,14 @@
   padding: 2px 4px;
   font-size: .75em;
 }
+
+.externalLink {
+  border-bottom: none;
+  &__Icon {
+    vertical-align: bottom;
+    height: 36px;
+    width: 26px;
+    border: none;
+    margin-left: 0.5em;
+  } 
+}


### PR DESCRIPTION
resolves #64 
Attaching screenshot and video interaction.
<img width="474" alt="Screenshot 2019-10-29 at 8 10 15 PM" src="https://user-images.githubusercontent.com/13138123/67778157-cccd1780-fa88-11e9-90f1-3cf3ee458a52.png">

![ExternalLink](https://user-images.githubusercontent.com/13138123/67778954-fdfa1780-fa89-11e9-8f89-fb4bbc18b9c8.gif)
