### PR TITLE
Explicitly specify build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "scripts": {
     "develop": "gatsby develop",
-    "start": "npm run develop"
+    "start": "npm run develop",
+    "build": "gatsby build"
   }
 }


### PR DESCRIPTION
This is in support of #60, separating it into a separate PR.

@wgao19 I'm guessing that in Netlify, the build command is specified as `gatsby build`. This change would require it to be changed to `yarn build`, so that we can manage what this command does from `package.json`, rather than in the Netlify console.

I think we could have addressed this using a `netlify.toml` file but since there isn't one I am going for this approach first.